### PR TITLE
rc-1.0.2

### DIFF
--- a/ansible/cage_configure.yml
+++ b/ansible/cage_configure.yml
@@ -30,12 +30,12 @@
     bastion_hostname: 
   tasks:
     - name: ensure that global dns can resolve cage
-      command: "dig +short SOA {{cage_name}}.{{customer_domain}}"
+      command: "dig +noadflag +short SOA {{cage_name}}.{{customer_domain}}"
       ignore_errors: true
       register: hostcmd
 
     - name: log error when cage not resolvable
-      fail: msg='Unable to use global DNS to resolve {{cage_name}}.{{customer_domain}}.  You can test this yourself by using "dig +short SOA {{cage_name}}.{{customer_domain}}".  Be sure that you have added NS records to the DNS zone file for {{customer_domain}} that delegate to the nameservers provisioned for {{cage_name}}.{{customer_domain}}.  You can find these nameservers from the AWS Route53 Management Console within the {{cage_name}}.{{customer_domain}} hosted zone".'
+      fail: msg='Unable to use global DNS to resolve {{cage_name}}.{{customer_domain}}.  You can test this yourself by using "dig +noadflag +short SOA {{cage_name}}.{{customer_domain}}".  Be sure that you have added NS records to the DNS zone file for {{customer_domain}} that delegate to the nameservers provisioned for {{cage_name}}.{{customer_domain}}.  You can find these nameservers from the AWS Route53 Management Console within the {{cage_name}}.{{customer_domain}} hosted zone".'
       when: hostcmd.rc != 0
 
     - name: ensure that bastion host can be looked up in dns

--- a/ansible/role_specification.yml
+++ b/ansible/role_specification.yml
@@ -78,6 +78,7 @@ role_specification:
                 - "ec2:AllocateAddress"
                 - "ec2:AssociateAddress"
                 - "ec2:ReplaceNetworkAclAssociation"
+                - "ec2:RevokeSecurityGroupIngress"
                 - "ec2:AssociateRouteTable"
                 - "ec2:DescribeAddresses"
                 - "ec2:RunInstances"

--- a/ansible/role_specification.yml
+++ b/ansible/role_specification.yml
@@ -64,6 +64,7 @@ role_specification:
                 - "ec2:CreateRouteTable"
                 - "ec2:CreateNetworkAcl"
                 - "ec2:CreateNetworkAclEntry"
+                - "ec2:DeleteNetworkAclEntry"
                 - "ec2:CreateSecurityGroup"
                 - "ec2:CreateRoute"
                 - "ec2:AttachInternetGateway"

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -59,13 +59,27 @@
   - name: restart sshd
     service: name=sshd state=restarted
     sudo: true
-    when: max_startups.changed
+    when: max_startups.changed and ansible_os_family == "RedHat"
+
+  - name: restart sshd
+#    service: name=sshd state=restarted
+    command: service ssh restart
+    sudo: true
+    when: max_startups.changed and ansible_os_family == "Debian"
 
   - name: install updates
     yum: name="*" state=latest
     sudo: true
     async: 7200
     poll: 10
+    when: ansible_os_family == "RedHat"
+
+  - name: install updates
+    apt: upgrade=dist
+    sudo: true
+    async: 7200
+    poll: 10
+    when: ansible_os_family == "Debian"
 
   - name: copy bash command prompt setup
     copy: src=bash-prompt dest=~/.bash-prompt
@@ -73,9 +87,13 @@
   - name: set bash command prompt
     lineinfile: dest="~/.bashrc" line=". ~/.bash-prompt"
 
+  - name: set startup file
+    set_fact:
+      rcfile: '{{ "/etc/rc.d/rc.local" if ansible_os_family == "RedHat" else "/etc/rc.local" }}'
+
   - name: set MTU to 1500 on eth0 to avoid ssh comms issues
     lineinfile:
-      dest=/etc/rc.d/rc.local
+      dest={{ rcfile }}
       regexp="^/sbin/ip link set dev eth0 mtu"
       line="/sbin/ip link set dev eth0 mtu 1500"
       insertafter="EOF"

--- a/ansible/roles/instantiate_cage_templates/templates/cage/cage.j2
+++ b/ansible/roles/instantiate_cage_templates/templates/cage/cage.j2
@@ -91,6 +91,33 @@
 		]
             }
         },
+        "PublicNetworkAclId": {
+            "Description": "ID of the Cage's Public Network ACL",
+            "Value": {
+                "Fn::GetAtt": [
+		    "Vpc",
+		    "Outputs.PublicNetworkAclId"
+		]
+            }
+        },
+        "PrivateNetworkAclId": {
+            "Description": "ID of the Cage's Private Network ACL",
+            "Value": {
+                "Fn::GetAtt": [
+		    "Vpc",
+		    "Outputs.PrivateNetworkAclId"
+		]
+            }
+        },
+        "DatabaseNetworkAclId": {
+            "Description": "ID of the Cage's Database Network ACL",
+            "Value": {
+                "Fn::GetAtt": [
+		    "Vpc",
+		    "Outputs.DatabaseNetworkAclId"
+		]
+            }
+        },
         "PublicSubnet1Id": {
             "Description": "ID of the first redundant public subnet",
             "Value": {

--- a/ansible/roles/instantiate_cage_templates/templates/cage/vpc.j2
+++ b/ansible/roles/instantiate_cage_templates/templates/cage/vpc.j2
@@ -1044,19 +1044,19 @@
         "PublicNetworkAclId": {
             "Description": "ID of the Cage's Public Network ACL",
             "Value": {
-                "Ref": "PublicNetwokAcl"
+                "Ref": "PublicNetworkAcl"
             }
         },
         "PrivateNetworkAclId": {
             "Description": "ID of the Cage's Private Network ACL",
             "Value": {
-                "Ref": "PrivateNetwokAcl"
+                "Ref": "PrivateNetworkAcl"
             }
         },
         "DatabaseNetworkAclId": {
             "Description": "ID of the Cage's Database Network ACL",
             "Value": {
-                "Ref": "DatabaseNetwokAcl"
+                "Ref": "DatabaseNetworkAcl"
             }
         },
         "PublicSubnet1Id": {

--- a/ansible/roles/instantiate_cage_templates/templates/cage/vpc.j2
+++ b/ansible/roles/instantiate_cage_templates/templates/cage/vpc.j2
@@ -1041,6 +1041,24 @@
                 "Ref": "BastionSecurityGroup"
             }
         },
+        "PublicNetworkAclId": {
+            "Description": "ID of the Cage's Public Network ACL",
+            "Value": {
+                "Ref": "PublicNetwokAcl"
+            }
+        },
+        "PrivateNetworkAclId": {
+            "Description": "ID of the Cage's Private Network ACL",
+            "Value": {
+                "Ref": "PrivateNetwokAcl"
+            }
+        },
+        "DatabaseNetworkAclId": {
+            "Description": "ID of the Cage's Database Network ACL",
+            "Value": {
+                "Ref": "DatabaseNetwokAcl"
+            }
+        },
         "PublicSubnet1Id": {
             "Description": "ID of the first redundant public subnet",
             "Value": {

--- a/ansible/roles/instantiate_cage_templates/vars/database_acl.yml
+++ b/ansible/roles/instantiate_cage_templates/vars/database_acl.yml
@@ -51,6 +51,16 @@ database_acl:
         PortRange:
           From: 3306
           To: 3306
+    - name: InboundRedshiftDbNeworkAclEntry
+      properties:
+        RuleNumber: 105
+        Protocol: 6 #tcp
+        RuleAction: allow
+        CidrBlock: '{{ network_topology.vpc_cidr }}'
+        PortRange:
+          From: 5439
+          To: 5439
+
 
   outbound_entries:
     - name: OutboundDbNetworkAclEntry

--- a/ansible/roles/instantiate_cage_templates/vars/vpc.yml
+++ b/ansible/roles/instantiate_cage_templates/vars/vpc.yml
@@ -31,12 +31,6 @@ nat_security_group_ingress:
       ToPort: "22"
       CidrIp: '{{ network_topology["private_cidr"] }}'
 
-    # outbound FTP via NAT requires inbound FTP to NAT from private subnet instances
-    - IpProtocol: "tcp"
-      FromPort: "21"
-      ToPort: "21"
-      CidrIp: '{{ network_topology["private_cidr"] }}'
-
     # outbound HTTP via NAT requires inbound HTTP to NAT from private subnet instances
     - IpProtocol: "tcp"
       FromPort: "80"
@@ -84,12 +78,6 @@ nat_security_group_egress:
     - IpProtocol: "tcp"
       FromPort: "22"
       ToPort: "22"
-      CidrIp: "0.0.0.0/0"
-
-    # outbound FTP to internet hosts
-    - IpProtocol: "tcp"
-      FromPort: "21"
-      ToPort: "21"
       CidrIp: "0.0.0.0/0"
 
     # outbound HTTP to internet hosts


### PR DESCRIPTION
Includes:

RS-568 Include version info upon nucleator update, add --version to report on currently installed versions
RS-665 Security hardening based on potential issues identified by CloudCheckr
RS-526 Enhance validation of siteconfig
RS-586 Support worker tier beanstalks
47lining/nucleator-core-redshift#1 Improved Support for Private Redshift Clusters
SSL process and documentation improvements for builder
Use ansible inventory mantained in ~/.nucleator for stronger stackset and end-user ease-of-use
